### PR TITLE
fix: wire description variable through to bigquery_dataset resource

### DIFF
--- a/cloud_resources/gcp/terraform/modules/bigquery_remote_function/README.md
+++ b/cloud_resources/gcp/terraform/modules/bigquery_remote_function/README.md
@@ -33,14 +33,15 @@ No modules.
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_app"></a> [app](#input\_app) | n/a | `string` | n/a | yes |
-| <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
-| <a name="input_notifier_function_name"></a> [notifier\_function\_name](#input\_notifier\_function\_name) | n/a | `string` | n/a | yes |
-| <a name="input_notifier_function_url"></a> [notifier\_function\_url](#input\_notifier\_function\_url) | n/a | `string` | n/a | yes |
-| <a name="input_project"></a> [project](#input\_project) | n/a | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
+| Name                                                                                                     | Description | Type | Default | Required |
+|----------------------------------------------------------------------------------------------------------|-------------|------|---------|:--------:|
+| <a name="input_app"></a> [app](#input\_app)                                                              | n/a | `string` | n/a     | yes |
+| <a name="input_env"></a> [env](#input\_env)                                                              | n/a | `string` | n/a     | yes |
+| <a name="input_notifier_function_name"></a> [notifier\_function\_name](#input\_notifier\_function\_name) | n/a | `string` | n/a     | yes |
+| <a name="input_notifier_function_url"></a> [notifier\_function\_url](#input\_notifier\_function\_url)    | n/a | `string` | n/a     | yes |
+| <a name="input_project"></a> [project](#input\_project)                                                  | n/a | `string` | n/a     | yes |
+| <a name="input_region"></a> [region](#input\_region)                                                     | n/a | `string` | n/a     | yes |
+| <a name="input_description"></a> [description](#input\_description)                                      | n/a | `string` | null    | yes |
 
 ## Outputs
 

--- a/cloud_resources/gcp/terraform/modules/bigquery_remote_function/bigquery.tf
+++ b/cloud_resources/gcp/terraform/modules/bigquery_remote_function/bigquery.tf
@@ -2,6 +2,7 @@ resource "google_bigquery_dataset" "notifier_ds" {
   dataset_id          = "file_notifier"
   location            = var.region
   project             = var.project
+  description         = var.description
   is_case_insensitive = true
 }
 

--- a/cloud_resources/gcp/terraform/modules/bigquery_remote_function/variables.tf
+++ b/cloud_resources/gcp/terraform/modules/bigquery_remote_function/variables.tf
@@ -21,3 +21,8 @@ variable "notifier_function_name" {
 variable "notifier_function_url" {
   type = string
 }
+
+variable "description" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
It just a simple change to propagate the description through the module so we can get rid of one of the minor bug that we have for over a year now:
resource "google_bigquery_dataset" "notifier_ds" {
- description                     = "Dataset for File notifier" -> null

which is caused by mismatch between input variables and the state file since the description is not wired through the external module in this repo. Now with every terraform workflow we have this artificial change that never happens and gets replanned and re-applied every time